### PR TITLE
remove background-color of black for entire site

### DIFF
--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -15,7 +15,6 @@ body {
   -o-background-size: cover;
   background-size: cover;
   background-attachment: fixed;
-  background-color: #000 !important;
 }
 
 a {


### PR DESCRIPTION
Removed `background-color: #000` to `globals.scss` in hopes that the background-gradient will work across the entire page.